### PR TITLE
Allow software Wire on eg Wemos/NodeMCU

### DIFF
--- a/src/TinyMPU6050.cpp
+++ b/src/TinyMPU6050.cpp
@@ -16,12 +16,14 @@ MPU6050::MPU6050(TwoWire &w) {
  *	Initialization method
  */
 
+#ifdef ESP8266
 void MPU6050::Initialize (int sda, int scl) {
 
 	// Beginning Wire
 	wire->begin(sda, scl);
 	BaseInititalize();
 }
+#endif
 
 void MPU6050::Initialize () {
 

--- a/src/TinyMPU6050.cpp
+++ b/src/TinyMPU6050.cpp
@@ -15,11 +15,22 @@ MPU6050::MPU6050(TwoWire &w) {
 /*
  *	Initialization method
  */
+
+void MPU6050::Initialize (int sda, int scl) {
+
+	// Beginning Wire
+	wire->begin(sda, scl);
+	BaseInititalize();
+}
+
 void MPU6050::Initialize () {
 
 	// Beginning Wire
 	wire->begin();
+	BaseInititalize();
+}
 
+void MPU6050::BaseInititalize () {
 	// Setting attributes with default values
 	filterAccelCoeff = DEFAULT_ACCEL_COEFF;
 	filterGyroCoeff = DEFAULT_GYRO_COEFF;

--- a/src/TinyMPU6050.h
+++ b/src/TinyMPU6050.h
@@ -60,11 +60,12 @@ class MPU6050 {
 	 */
 	public:
 
-		// Constructor
-		MPU6050 (TwoWire &w);
+        // Constructor
+        MPU6050 (TwoWire &w);
 
-		// Setup method
-		void Initialize ();
+        // Setup method
+        void Initialize ();
+        void Initialize (int sda, int scl);
 
         // Method that updates all attributes
         void Execute ();
@@ -169,6 +170,7 @@ class MPU6050 {
 		// Z-axis deadzone stuff
 		float zAccelDeadzone, zGyroDeadzone, zAccelDeadzoneThreshold, zGyroDeadzoneThreshold;
 
+        void BaseInititalize ();
 };
 
 #endif

--- a/src/TinyMPU6050.h
+++ b/src/TinyMPU6050.h
@@ -65,7 +65,9 @@ class MPU6050 {
 
         // Setup method
         void Initialize ();
+#ifdef ESP8266
         void Initialize (int sda, int scl);
+#endif
 
         // Method that updates all attributes
         void Execute ();


### PR DESCRIPTION
For use on Wemos with eg Wire on D3 and D4, the default wire.begin must be passed the pins.