### PR TITLE
Ensure reliable endianness of retrieved data

### DIFF
--- a/src/TinyMPU6050.cpp
+++ b/src/TinyMPU6050.cpp
@@ -155,7 +155,9 @@ void MPU6050::UpdateRawGyro () {
 
 	rawGyroY = wire->read() << 8;
 	rawGyroY |= wire->read();
-	rawGyroZ = wire->read() << 8 | wire->read();
+
+	rawGyroZ = wire->read() << 8;
+	rawGyroZ |= wire->read();
 }
 
 /*


### PR DESCRIPTION
In the expression

```c++
wire->read() << 8 | wire->read()
```

C++ does not guarantee the order of evaluation of the two calls to `wire->read()`. We get this guarantee by putting the calls into separate statements.

Fixes #12.
