### PR TITLE
Use precalculated factors

### DIFF
--- a/src/TinyMPU6050.cpp
+++ b/src/TinyMPU6050.cpp
@@ -98,12 +98,12 @@ void MPU6050::Execute () {
 	this->UpdateRawGyro();
 
 	// Computing readable accel/gyro data
-	accX = (float)(rawAccX) / ACCEL_TRANSFORMATION_NUMBER;
-	accY = (float)(rawAccY) / ACCEL_TRANSFORMATION_NUMBER;
-	accZ = (float)(rawAccZ) / ACCEL_TRANSFORMATION_NUMBER;
-	gyroX = (float)(rawGyroX - gyroXOffset) / GYRO_TRANSFORMATION_NUMBER;
-	gyroY = (float)(rawGyroY - gyroYOffset) / GYRO_TRANSFORMATION_NUMBER;
-	gyroZ = (float)(rawGyroZ - gyroZOffset) / GYRO_TRANSFORMATION_NUMBER;
+	accX = (float)(rawAccX) * ACCEL_TRANSFORMATION_NUMBER;
+	accY = (float)(rawAccY) * ACCEL_TRANSFORMATION_NUMBER;
+	accZ = (float)(rawAccZ) * ACCEL_TRANSFORMATION_NUMBER;
+	gyroX = (float)(rawGyroX - gyroXOffset) * GYRO_TRANSFORMATION_NUMBER;
+	gyroY = (float)(rawGyroY - gyroYOffset) * GYRO_TRANSFORMATION_NUMBER;
+	gyroZ = (float)(rawGyroZ - gyroZOffset) * GYRO_TRANSFORMATION_NUMBER;
 
 	// Computing accel angles
 	angAccX = wrap((atan2(accY, sqrt(accZ * accZ + accX * accX))) * RAD_TO_DEG);

--- a/src/TinyMPU6050.h
+++ b/src/TinyMPU6050.h
@@ -36,8 +36,8 @@
  *  Macros
  */
 // For execution
-#define ACCEL_TRANSFORMATION_NUMBER     16384
-#define GYRO_TRANSFORMATION_NUMBER      65.536
+#define ACCEL_TRANSFORMATION_NUMBER     0.00006103515 // (1 / 16384) precalculated
+#define GYRO_TRANSFORMATION_NUMBER      0.01525878906 // (1 / 65.536) precalculated
 // For digital filter
 #define DEFAULT_ACCEL_COEFF             0.02f
 #define DEFAULT_GYRO_COEFF              0.98f


### PR DESCRIPTION
Replacing `floating point division` with `floating point multiplication` for faster data processing in main loop.